### PR TITLE
Breaking down the code into separate Header and Map modules

### DIFF
--- a/src/Header.elm
+++ b/src/Header.elm
@@ -1,0 +1,18 @@
+module Header exposing (..)
+
+import Map exposing (SpeciesCode(..))
+
+
+
+-- Model & init
+
+
+type alias HeaderModel =
+    { species : SpeciesCode
+    }
+
+
+initHeader : HeaderModel
+initHeader =
+    { species = NO2
+    }

--- a/src/Header.elm
+++ b/src/Header.elm
@@ -1,6 +1,7 @@
 module Header exposing (..)
 
-import Map exposing (SpeciesCode(..))
+import Map exposing (MapMsg(..), SpeciesCode(..))
+import Task
 
 
 
@@ -16,3 +17,25 @@ initHeader : HeaderModel
 initHeader =
     { species = NO2
     }
+
+
+
+-- Msg & update
+
+
+type HeaderMsg
+    = SelectSpecies SpeciesCode
+    | EmitMapMsg MapMsg
+
+
+updateHeader : HeaderMsg -> HeaderModel -> ( HeaderModel, Cmd HeaderMsg )
+updateHeader msg header =
+    case msg of
+        SelectSpecies species ->
+            ( { header | species = species }
+            , UpdateMarkers species |> Task.succeed |> Task.perform EmitMapMsg
+            )
+
+        EmitMapMsg _ ->
+            -- This message is handled upstream, in Main.update
+            ( header, Cmd.none )

--- a/src/Header.elm
+++ b/src/Header.elm
@@ -1,6 +1,9 @@
 module Header exposing (..)
 
-import Map exposing (MapMsg(..), SpeciesCode(..))
+import Html exposing (Html, a, div, h1, i, span, text)
+import Html.Attributes exposing (class, href, style, target)
+import Html.Events exposing (onClick)
+import Map exposing (MapMsg(..), SpeciesCode(..), allSpeciesCode, speciesCodeToString)
 import Task
 
 
@@ -39,3 +42,63 @@ updateHeader msg header =
         EmitMapMsg _ ->
             -- This message is handled upstream, in Main.update
             ( header, Cmd.none )
+
+
+
+-- View
+
+
+viewHeader : HeaderModel -> Html HeaderMsg
+viewHeader header =
+    div [ class "hero is-small" ]
+        [ div [ class "hero-body" ]
+            [ div [ class "navbar" ]
+                [ div [ class "navbar-brand" ]
+                    [ div [ class "navbar-item" ]
+                        [ h1 [ class "title is-3", style "text-shadow" "2px 2px #b2d3c2" ] [ text "London Air" ]
+                        ]
+                    ]
+                , div [ class "navbar-menu" ]
+                    [ div [ class "navbar-start" ]
+                        [ div [ class "navbar-item has-dropdown is-hoverable" ]
+                            [ div [ class "navbar-link" ]
+                                [ text (speciesCodeToString header.species) ]
+                            , div [ class "navbar-dropdown" ]
+                                (allSpeciesCode |> List.map (viewDropdownItem header))
+                            ]
+                        ]
+                    , div [ class "navbar-end" ]
+                        [ div [ class "navbar-item" ]
+                            [ a
+                                [ class "button has-text-weight-semibold"
+                                , href "https://www.londonair.org.uk/LondonAir/API/"
+                                , target "_blank"
+                                ]
+                                [ span [ class "icon" ] [ i [ class "fa-solid fa-server" ] [] ]
+                                , span [] [ text "London Air API" ]
+                                ]
+                            ]
+                        , div [ class "navbar-item" ]
+                            [ a
+                                [ class "button is-success has-text-weight-semibold"
+                                , href "https://github.com/sophiecollard/london-air-ui"
+                                , target "_blank"
+                                ]
+                                [ span [ class "icon" ] [ i [ class "fab fa-github" ] [] ]
+                                , span [] [ text "View on GitHub" ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]
+
+
+viewDropdownItem : HeaderModel -> SpeciesCode -> Html HeaderMsg
+viewDropdownItem header code =
+    if header.species == code then
+        div [ class "navbar-item has-text-weight-semibold" ] [ text (speciesCodeToString code) ]
+
+    else
+        a [ class "navbar-item", onClick (SelectSpecies code) ] [ text (speciesCodeToString code) ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,10 +1,8 @@
 module Main exposing (..)
 
 import Browser
-import Header exposing (HeaderModel, HeaderMsg(..), initHeader, updateHeader)
-import Html exposing (Html, a, div, h1, i, span, text)
-import Html.Attributes exposing (class, href, id, style, target)
-import Html.Events exposing (onClick)
+import Header exposing (HeaderModel, HeaderMsg(..), initHeader, updateHeader, viewHeader)
+import Html exposing (Html, div)
 import Map exposing (..)
 
 
@@ -103,62 +101,6 @@ subscriptions _ =
 view : Model -> Html Msg
 view model =
     div []
-        [ viewHeader model
-        , div [ id "map", style "min-height" "90vh", style "z-index" "0" ] []
+        [ viewHeader model.header |> Html.map HeaderMsg
+        , viewMap
         ]
-
-
-viewHeader : Model -> Html Msg
-viewHeader model =
-    div [ class "hero is-small" ]
-        [ div [ class "hero-body" ]
-            [ div [ class "navbar" ]
-                [ div [ class "navbar-brand" ]
-                    [ div [ class "navbar-item" ]
-                        [ h1 [ class "title is-3", style "text-shadow" "2px 2px #b2d3c2" ] [ text "London Air" ]
-                        ]
-                    ]
-                , div [ class "navbar-menu" ]
-                    [ div [ class "navbar-start" ]
-                        [ div [ class "navbar-item has-dropdown is-hoverable" ]
-                            [ div [ class "navbar-link" ]
-                                [ text (speciesCodeToString model.header.species) ]
-                            , div [ class "navbar-dropdown" ]
-                                (allSpeciesCode |> List.map (viewDropdownItem model) |> List.map (Html.map HeaderMsg))
-                            ]
-                        ]
-                    , div [ class "navbar-end" ]
-                        [ div [ class "navbar-item" ]
-                            [ a
-                                [ class "button has-text-weight-semibold"
-                                , href "https://www.londonair.org.uk/LondonAir/API/"
-                                , target "_blank"
-                                ]
-                                [ span [ class "icon" ] [ i [ class "fa-solid fa-server" ] [] ]
-                                , span [] [ text "London Air API" ]
-                                ]
-                            ]
-                        , div [ class "navbar-item" ]
-                            [ a
-                                [ class "button is-success has-text-weight-semibold"
-                                , href "https://github.com/sophiecollard/london-air-ui"
-                                , target "_blank"
-                                ]
-                                [ span [ class "icon" ] [ i [ class "fab fa-github" ] [] ]
-                                , span [] [ text "View on GitHub" ]
-                                ]
-                            ]
-                        ]
-                    ]
-                ]
-            ]
-        ]
-
-
-viewDropdownItem : Model -> SpeciesCode -> Html HeaderMsg
-viewDropdownItem model code =
-    if model.header.species == code then
-        div [ class "navbar-item has-text-weight-semibold" ] [ text (speciesCodeToString code) ]
-
-    else
-        a [ class "navbar-item", onClick (SelectSpecies code) ] [ text (speciesCodeToString code) ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,14 +1,14 @@
 module Main exposing (..)
 
 import Browser
+import Header exposing (HeaderModel, initHeader)
 import Html exposing (Html, a, div, h1, i, span, text)
 import Html.Attributes exposing (class, href, id, style, target)
 import Html.Events exposing (onClick)
 import Http
-import Json.Decode exposing (Decoder, andThen, field, oneOf)
 import Json.Encode
 import Leaflet
-import Utils.List
+import Map exposing (..)
 
 
 
@@ -29,319 +29,14 @@ main =
 
 
 type alias Model =
-    { species : SpeciesCode
-    , data : Data
+    { header : HeaderModel
+    , map : MapModel
     }
 
 
 init : () -> ( Model, Cmd Msg )
 init _ =
-    ( Model NO2 Loading, getDailyAirQualityData )
-
-
-type Data
-    = Loading
-    | Loaded DailyAirQualityData
-    | Error String
-
-
-type alias DailyAirQualityData =
-    { groupName : String
-    , localAuthority : List LocalAuthority
-    }
-
-
-dailyAirQualityDataDecoder : Decoder DailyAirQualityData
-dailyAirQualityDataDecoder =
-    let
-        innerDecoder =
-            Json.Decode.map2 DailyAirQualityData
-                (field "@GroupName" Json.Decode.string)
-                (field "LocalAuthority" (Json.Decode.list localAuthorityDecoder))
-    in
-    Json.Decode.map identity
-        (field "DailyAirQualityIndex" innerDecoder)
-
-
-type alias LocalAuthority =
-    { code : String
-    , name : String
-    , lat : Float
-    , lng : Float
-    , site : List Site
-    }
-
-
-localAuthorityDecoder : Decoder LocalAuthority
-localAuthorityDecoder =
-    Json.Decode.map5 LocalAuthority
-        (field "@LocalAuthorityCode" Json.Decode.string)
-        (field "@LocalAuthorityName" Json.Decode.string)
-        (field "@LaCentreLatitude" Json.Decode.string |> andThen floatAsStringDecoder)
-        (field "@LaCentreLongitude" Json.Decode.string |> andThen floatAsStringDecoder)
-        (oneOf
-            [ field "Site" (Json.Decode.list siteDecoder)
-            , Json.Decode.succeed []
-            ]
-        )
-
-
-type alias Site =
-    { code : String
-    , name : String
-    , lat : Float
-    , lng : Float
-    , species : List Species
-    }
-
-
-siteDecoder : Decoder Site
-siteDecoder =
-    Json.Decode.map5 Site
-        (field "@SiteCode" Json.Decode.string)
-        (field "@SiteName" Json.Decode.string)
-        (field "@Latitude" (Json.Decode.string |> andThen floatAsStringDecoder))
-        (field "@Longitude" (Json.Decode.string |> andThen floatAsStringDecoder))
-        (oneOf
-            [ field "Species" (Json.Decode.list speciesDecoder)
-            , Json.Decode.succeed []
-            ]
-        )
-
-
-type alias Species =
-    { code : SpeciesCode
-    , airQualityIndex : String
-    , airQualityBand : AirQualityBand
-    , source : String
-    }
-
-
-speciesDecoder : Decoder Species
-speciesDecoder =
-    Json.Decode.map4 Species
-        (field "@SpeciesCode" speciesCodeDecoder)
-        (field "@AirQualityIndex" Json.Decode.string)
-        (field "@AirQualityBand" airQualityBandDecoder)
-        (field "@IndexSource" Json.Decode.string)
-
-
-type AirQualityBand
-    = Low
-    | Moderate
-    | High
-    | VeryHigh
-
-
-airQualityBandToString : AirQualityBand -> String
-airQualityBandToString band =
-    case band of
-        Low ->
-            "Low"
-
-        Moderate ->
-            "Moderate"
-
-        High ->
-            "High"
-
-        VeryHigh ->
-            "Very High"
-
-
-airQualityBandDecoder : Decoder AirQualityBand
-airQualityBandDecoder =
-    let
-        fromString str =
-            case str of
-                "Low" ->
-                    Json.Decode.succeed Low
-
-                "Moderate" ->
-                    Json.Decode.succeed Moderate
-
-                "High" ->
-                    Json.Decode.succeed High
-
-                "Very High" ->
-                    Json.Decode.succeed VeryHigh
-
-                other ->
-                    Json.Decode.fail ("Failed to decode air quality index from " ++ other)
-    in
-    Json.Decode.string |> andThen fromString
-
-
-type SpeciesCode
-    = CO
-    | NO2
-    | O3
-    | PM10
-    | PM25
-    | SO2
-
-
-allSpeciesCode : List SpeciesCode
-allSpeciesCode =
-    [ CO, NO2, O3, PM10, PM25, SO2 ]
-
-
-speciesCodeToString : SpeciesCode -> String
-speciesCodeToString code =
-    case code of
-        CO ->
-            "Carbon Monoxide (CO)"
-
-        NO2 ->
-            "Nitrogen Dioxide (NO2)"
-
-        O3 ->
-            "Ozone (O3)"
-
-        PM10 ->
-            "PM10 Particules"
-
-        PM25 ->
-            "PM2.5 Particules"
-
-        SO2 ->
-            "Sulphur Dioxide (SO2)"
-
-
-speciesCodeDecoder : Decoder SpeciesCode
-speciesCodeDecoder =
-    let
-        fromString str =
-            case str of
-                "CO" ->
-                    Json.Decode.succeed CO
-
-                "NO2" ->
-                    Json.Decode.succeed NO2
-
-                "O3" ->
-                    Json.Decode.succeed O3
-
-                "PM10" ->
-                    Json.Decode.succeed PM10
-
-                "PM25" ->
-                    Json.Decode.succeed PM25
-
-                "SO2" ->
-                    Json.Decode.succeed SO2
-
-                other ->
-                    Json.Decode.fail ("Failed to decode species code from " ++ other)
-    in
-    Json.Decode.string |> andThen fromString
-
-
-floatAsStringDecoder : String -> Decoder Float
-floatAsStringDecoder str =
-    case String.toFloat str of
-        Just float ->
-            Json.Decode.succeed float
-
-        Nothing ->
-            Json.Decode.fail ("Failed to decode float from " ++ str)
-
-
-type alias Marker =
-    { lat : Float
-    , lng : Float
-    , color : MarkerColor
-    , tooltip : String
-    , popupContents : String
-    }
-
-
-markersFromData : DailyAirQualityData -> SpeciesCode -> List Marker
-markersFromData data code =
-    data.localAuthority
-        |> Utils.List.flatMap .site
-        |> Utils.List.flatMap (\site -> List.map (\s -> ( site, s )) site.species)
-        |> List.filter (\( _, species ) -> species.code == code)
-        |> List.map markerForSiteSpecies
-
-
-markerForSiteSpecies : ( Site, Species ) -> Marker
-markerForSiteSpecies ( site, species ) =
-    let
-        popupContents =
-            "<div class=\"content\">"
-                ++ "<h1 class=\"title is-6\">"
-                ++ site.name
-                ++ "</h1>"
-                ++ "<h2 class=\"subtitle is-7 has-text-weight-normal\">"
-                ++ speciesCodeToString species.code
-                ++ "</h2>"
-                ++ "<ul>"
-                ++ "<li>Air quality index: "
-                ++ species.airQualityIndex
-                ++ "</li>"
-                ++ "<li>Air quality band: "
-                ++ airQualityBandToString species.airQualityBand
-                ++ "</li>"
-                ++ "</ul>"
-                ++ "</div>"
-    in
-    { lat = site.lat
-    , lng = site.lng
-    , color = colorFromAirQualityBand species.airQualityBand
-    , tooltip = site.name
-    , popupContents = popupContents
-    }
-
-
-markerEncoder : Marker -> Json.Encode.Value
-markerEncoder marker =
-    Json.Encode.object
-        [ ( "lat", Json.Encode.float marker.lat )
-        , ( "lng", Json.Encode.float marker.lng )
-        , ( "iconUrl", iconUrlEncoder marker.color )
-        , ( "title", Json.Encode.string marker.tooltip )
-        , ( "popupContents", Json.Encode.string marker.popupContents )
-        ]
-
-
-type MarkerColor
-    = Green
-    | Yellow
-    | Red
-    | Black
-
-
-colorFromAirQualityBand : AirQualityBand -> MarkerColor
-colorFromAirQualityBand band =
-    case band of
-        Low ->
-            Green
-
-        Moderate ->
-            Yellow
-
-        High ->
-            Red
-
-        VeryHigh ->
-            Black
-
-
-iconUrlEncoder : MarkerColor -> Json.Encode.Value
-iconUrlEncoder markerColor =
-    case markerColor of
-        Green ->
-            Json.Encode.string "https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-green.png"
-
-        Yellow ->
-            Json.Encode.string "https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-gold.png"
-
-        Red ->
-            Json.Encode.string "https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-red.png"
-
-        Black ->
-            Json.Encode.string "https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-black.png"
+    ( { header = initHeader, map = initMap }, getDailyAirQualityData )
 
 
 
@@ -359,8 +54,11 @@ update msg model =
     case msg of
         SelectSpecies species ->
             let
+                header =
+                    model.header
+
                 newModel =
-                    { model | species = species }
+                    { model | header = { header | species = species } }
             in
             ( newModel, updateMarkers newModel )
 
@@ -368,36 +66,40 @@ update msg model =
             ( model, getDailyAirQualityData )
 
         GotDailyAirQualityData result ->
+            let
+                map =
+                    model.map
+            in
             case result of
                 Ok dailyAirQualityData ->
                     let
                         newModel =
-                            { model | data = Loaded dailyAirQualityData }
+                            { model | map = { map | data = Loaded dailyAirQualityData } }
                     in
                     ( newModel, updateMarkers newModel )
 
                 Err (Http.BadBody bodyError) ->
-                    ( { model | data = Error ("Encountered bad body error: " ++ bodyError) }
+                    ( { model | map = { map | data = Error ("Encountered bad body error: " ++ bodyError) } }
                     , Cmd.none
                     )
 
                 Err (Http.BadStatus status) ->
-                    ( { model | data = Error ("Encountered bad status error: " ++ String.fromInt status) }
+                    ( { model | map = { map | data = Error ("Encountered bad status error: " ++ String.fromInt status) } }
                     , Cmd.none
                     )
 
                 Err (Http.BadUrl url) ->
-                    ( { model | data = Error ("Encountered bad URL error: " ++ url) }
+                    ( { model | map = { map | data = Error ("Encountered bad URL error: " ++ url) } }
                     , Cmd.none
                     )
 
                 Err Http.NetworkError ->
-                    ( { model | data = Error "Encountered network error" }
+                    ( { model | map = { map | data = Error "Encountered network error" } }
                     , Cmd.none
                     )
 
                 Err Http.Timeout ->
-                    ( { model | data = Error "Encountered timeout error" }
+                    ( { model | map = { map | data = Error "Encountered timeout error" } }
                     , Cmd.none
                     )
 
@@ -419,9 +121,9 @@ updateMarkers : Model -> Cmd msg
 updateMarkers model =
     let
         markers =
-            case model.data of
+            case model.map.data of
                 Loaded data ->
-                    markersFromData data model.species
+                    markersFromData data model.header.species
 
                 _ ->
                     []
@@ -465,7 +167,7 @@ viewHeader model =
                     [ div [ class "navbar-start" ]
                         [ div [ class "navbar-item has-dropdown is-hoverable" ]
                             [ div [ class "navbar-link" ]
-                                [ text (speciesCodeToString model.species) ]
+                                [ text (speciesCodeToString model.header.species) ]
                             , div [ class "navbar-dropdown" ]
                                 (List.map (viewDropdownItem model) allSpeciesCode)
                             ]
@@ -500,7 +202,7 @@ viewHeader model =
 
 viewDropdownItem : Model -> SpeciesCode -> Html Msg
 viewDropdownItem model code =
-    if model.species == code then
+    if model.header.species == code then
         div [ class "navbar-item has-text-weight-semibold" ] [ text (speciesCodeToString code) ]
 
     else

--- a/src/Map.elm
+++ b/src/Map.elm
@@ -1,0 +1,325 @@
+module Map exposing (..)
+
+import Json.Decode exposing (Decoder, andThen, field, oneOf)
+import Json.Encode
+import Utils.List
+
+
+
+-- Model & init
+
+
+type alias MapModel =
+    { data : Data
+    }
+
+
+initMap : MapModel
+initMap =
+    { data = Loading
+    }
+
+
+type Data
+    = Loading
+    | Loaded DailyAirQualityData
+    | Error String
+
+
+type alias DailyAirQualityData =
+    { groupName : String
+    , localAuthority : List LocalAuthority
+    }
+
+
+dailyAirQualityDataDecoder : Decoder DailyAirQualityData
+dailyAirQualityDataDecoder =
+    let
+        innerDecoder =
+            Json.Decode.map2 DailyAirQualityData
+                (field "@GroupName" Json.Decode.string)
+                (field "LocalAuthority" (Json.Decode.list localAuthorityDecoder))
+    in
+    Json.Decode.map identity
+        (field "DailyAirQualityIndex" innerDecoder)
+
+
+type alias LocalAuthority =
+    { code : String
+    , name : String
+    , lat : Float
+    , lng : Float
+    , site : List Site
+    }
+
+
+localAuthorityDecoder : Decoder LocalAuthority
+localAuthorityDecoder =
+    Json.Decode.map5 LocalAuthority
+        (field "@LocalAuthorityCode" Json.Decode.string)
+        (field "@LocalAuthorityName" Json.Decode.string)
+        (field "@LaCentreLatitude" Json.Decode.string |> andThen floatAsStringDecoder)
+        (field "@LaCentreLongitude" Json.Decode.string |> andThen floatAsStringDecoder)
+        (oneOf
+            [ field "Site" (Json.Decode.list siteDecoder)
+            , Json.Decode.succeed []
+            ]
+        )
+
+
+type alias Site =
+    { code : String
+    , name : String
+    , lat : Float
+    , lng : Float
+    , species : List Species
+    }
+
+
+siteDecoder : Decoder Site
+siteDecoder =
+    Json.Decode.map5 Site
+        (field "@SiteCode" Json.Decode.string)
+        (field "@SiteName" Json.Decode.string)
+        (field "@Latitude" (Json.Decode.string |> andThen floatAsStringDecoder))
+        (field "@Longitude" (Json.Decode.string |> andThen floatAsStringDecoder))
+        (oneOf
+            [ field "Species" (Json.Decode.list speciesDecoder)
+            , Json.Decode.succeed []
+            ]
+        )
+
+
+type alias Species =
+    { code : SpeciesCode
+    , airQualityIndex : String
+    , airQualityBand : AirQualityBand
+    , source : String
+    }
+
+
+speciesDecoder : Decoder Species
+speciesDecoder =
+    Json.Decode.map4 Species
+        (field "@SpeciesCode" speciesCodeDecoder)
+        (field "@AirQualityIndex" Json.Decode.string)
+        (field "@AirQualityBand" airQualityBandDecoder)
+        (field "@IndexSource" Json.Decode.string)
+
+
+type AirQualityBand
+    = Low
+    | Moderate
+    | High
+    | VeryHigh
+
+
+airQualityBandToString : AirQualityBand -> String
+airQualityBandToString band =
+    case band of
+        Low ->
+            "Low"
+
+        Moderate ->
+            "Moderate"
+
+        High ->
+            "High"
+
+        VeryHigh ->
+            "Very High"
+
+
+airQualityBandDecoder : Decoder AirQualityBand
+airQualityBandDecoder =
+    let
+        fromString str =
+            case str of
+                "Low" ->
+                    Json.Decode.succeed Low
+
+                "Moderate" ->
+                    Json.Decode.succeed Moderate
+
+                "High" ->
+                    Json.Decode.succeed High
+
+                "Very High" ->
+                    Json.Decode.succeed VeryHigh
+
+                other ->
+                    Json.Decode.fail ("Failed to decode air quality index from " ++ other)
+    in
+    Json.Decode.string |> andThen fromString
+
+
+type SpeciesCode
+    = CO
+    | NO2
+    | O3
+    | PM10
+    | PM25
+    | SO2
+
+
+allSpeciesCode : List SpeciesCode
+allSpeciesCode =
+    [ CO, NO2, O3, PM10, PM25, SO2 ]
+
+
+speciesCodeToString : SpeciesCode -> String
+speciesCodeToString code =
+    case code of
+        CO ->
+            "Carbon Monoxide (CO)"
+
+        NO2 ->
+            "Nitrogen Dioxide (NO2)"
+
+        O3 ->
+            "Ozone (O3)"
+
+        PM10 ->
+            "PM10 Particules"
+
+        PM25 ->
+            "PM2.5 Particules"
+
+        SO2 ->
+            "Sulphur Dioxide (SO2)"
+
+
+speciesCodeDecoder : Decoder SpeciesCode
+speciesCodeDecoder =
+    let
+        fromString str =
+            case str of
+                "CO" ->
+                    Json.Decode.succeed CO
+
+                "NO2" ->
+                    Json.Decode.succeed NO2
+
+                "O3" ->
+                    Json.Decode.succeed O3
+
+                "PM10" ->
+                    Json.Decode.succeed PM10
+
+                "PM25" ->
+                    Json.Decode.succeed PM25
+
+                "SO2" ->
+                    Json.Decode.succeed SO2
+
+                other ->
+                    Json.Decode.fail ("Failed to decode species code from " ++ other)
+    in
+    Json.Decode.string |> andThen fromString
+
+
+floatAsStringDecoder : String -> Decoder Float
+floatAsStringDecoder str =
+    case String.toFloat str of
+        Just float ->
+            Json.Decode.succeed float
+
+        Nothing ->
+            Json.Decode.fail ("Failed to decode float from " ++ str)
+
+
+type alias Marker =
+    { lat : Float
+    , lng : Float
+    , color : MarkerColor
+    , tooltip : String
+    , popupContents : String
+    }
+
+
+markersFromData : DailyAirQualityData -> SpeciesCode -> List Marker
+markersFromData data code =
+    data.localAuthority
+        |> Utils.List.flatMap .site
+        |> Utils.List.flatMap (\site -> List.map (\s -> ( site, s )) site.species)
+        |> List.filter (\( _, species ) -> species.code == code)
+        |> List.map markerForSiteSpecies
+
+
+markerForSiteSpecies : ( Site, Species ) -> Marker
+markerForSiteSpecies ( site, species ) =
+    let
+        popupContents =
+            "<div class=\"content\">"
+                ++ "<h1 class=\"title is-6\">"
+                ++ site.name
+                ++ "</h1>"
+                ++ "<h2 class=\"subtitle is-7 has-text-weight-normal\">"
+                ++ speciesCodeToString species.code
+                ++ "</h2>"
+                ++ "<ul>"
+                ++ "<li>Air quality index: "
+                ++ species.airQualityIndex
+                ++ "</li>"
+                ++ "<li>Air quality band: "
+                ++ airQualityBandToString species.airQualityBand
+                ++ "</li>"
+                ++ "</ul>"
+                ++ "</div>"
+    in
+    { lat = site.lat
+    , lng = site.lng
+    , color = colorFromAirQualityBand species.airQualityBand
+    , tooltip = site.name
+    , popupContents = popupContents
+    }
+
+
+markerEncoder : Marker -> Json.Encode.Value
+markerEncoder marker =
+    Json.Encode.object
+        [ ( "lat", Json.Encode.float marker.lat )
+        , ( "lng", Json.Encode.float marker.lng )
+        , ( "iconUrl", iconUrlEncoder marker.color )
+        , ( "title", Json.Encode.string marker.tooltip )
+        , ( "popupContents", Json.Encode.string marker.popupContents )
+        ]
+
+
+type MarkerColor
+    = Green
+    | Yellow
+    | Red
+    | Black
+
+
+colorFromAirQualityBand : AirQualityBand -> MarkerColor
+colorFromAirQualityBand band =
+    case band of
+        Low ->
+            Green
+
+        Moderate ->
+            Yellow
+
+        High ->
+            Red
+
+        VeryHigh ->
+            Black
+
+
+iconUrlEncoder : MarkerColor -> Json.Encode.Value
+iconUrlEncoder markerColor =
+    case markerColor of
+        Green ->
+            Json.Encode.string "https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-green.png"
+
+        Yellow ->
+            Json.Encode.string "https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-gold.png"
+
+        Red ->
+            Json.Encode.string "https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-red.png"
+
+        Black ->
+            Json.Encode.string "https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-2x-black.png"

--- a/src/Map.elm
+++ b/src/Map.elm
@@ -1,5 +1,7 @@
 module Map exposing (..)
 
+import Html exposing (Html, div)
+import Html.Attributes exposing (id, style)
 import Http
 import Json.Decode exposing (Decoder, andThen, field, oneOf)
 import Json.Encode
@@ -411,3 +413,12 @@ updateMarkers map speciesCode =
     in
     Json.Encode.list markerEncoder markers
         |> Leaflet.resetMarkers
+
+
+
+-- View
+
+
+viewMap : Html msg
+viewMap =
+    div [ id "map", style "min-height" "90vh", style "z-index" "0" ] []


### PR DESCRIPTION
For demonstration purposes only. This PR shows how I would approach breaking down a growing Elm application into modules. In this case, I am splitting my app into `Header` and `Map` modules.

The boundaries between components can sometimes be blurry and subject to interpretation. I could have decided to keep track of the `Data` in `HeaderModel` instead of `MapModel`. The `GetDailyAirQualityData` and `GotDailyAirQualityData` messages would have followed suit and gone into the `Header` module. While perfectly sensible, this split would have resulted in a nearly empty `Map` module and made for a much less interesting example.

In practice, I wouldn't worry about breaking down my `Main.elm` file until it reaches approx 1,000 LOC.